### PR TITLE
build ts before publishing from ci; move @reduxjs/toolkit to dependency

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
           node-version: 14.x
       - run: echo "Installing project dependencies..."
       - run: npm ci
+      - run: echo "Building package..."
+      - run: npm run build
       - run: echo "Publishing package to NPM registry..."
       - uses: JS-DevTools/npm-publish@v1
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-meraki/dashboard-api-tools",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -352,7 +352,6 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
       "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -746,10 +745,9 @@
       }
     },
     "@reduxjs/toolkit": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.2.tgz",
-      "integrity": "sha512-CtPw5TkN1pHRigMFCOS/0qg3b/yfPV5qGCsltVnIz7bx4PKTJlGHYfIxm97qskLknMzuGfjExaYdXJ77QTL0vg==",
-      "dev": true,
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.3.tgz",
+      "integrity": "sha512-lU/LDIfORmjBbyDLaqFN2JB9YmAT1BElET9y0ZszwhSBa5Ef3t6o5CrHupw5J1iOXwd+o92QfQZ8OJpwXvsssg==",
       "requires": {
         "immer": "^9.0.7",
         "redux": "^4.1.2",
@@ -2230,8 +2228,7 @@
     "immer": {
       "version": "9.0.15",
       "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.15.tgz",
-      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ==",
-      "dev": true
+      "integrity": "sha512-2eB/sswms9AEUSkOm4SbV5Y7Vmt/bKRwByd52jfLkW4OLYeaTP3EEiJ9agqU0O/tq6Dk62Zfj+TJSqfm1rLVGQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -3442,7 +3439,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
       "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
@@ -3450,14 +3446,12 @@
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "dev": true
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
-      "dev": true
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regexpp": {
       "version": "3.2.0",
@@ -3474,8 +3468,7 @@
     "reselect": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
-      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==",
-      "dev": true
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.22.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cisco-meraki/dashboard-api-tools",
   "author": "Cisco Meraki",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Typescript library for interacting with Meraki's public API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,7 +28,6 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@reduxjs/toolkit": "^1.7.1",
     "@testing-library/react": "^12.1.3",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
@@ -49,5 +48,8 @@
   "bugs": {
     "url": "https://github.com/meraki/dashboard-api-tools/issues"
   },
-  "homepage": "https://github.com/meraki/dashboard-api-tools#readme"
+  "homepage": "https://github.com/meraki/dashboard-api-tools#readme",
+  "dependencies": {
+    "@reduxjs/toolkit": "^1.8.3"
+  }
 }


### PR DESCRIPTION
I think having `@reduxjs/toolkit` as a dev dependency doesn't transitively install it, which means the client must already have this library installed. But it is required for prod code to work, not just tests