### PR TITLE
Fix bug with action batch responses returning errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-meraki/dashboard-api-tools",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cisco-meraki/dashboard-api-tools",
   "author": "Cisco Meraki",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Typescript library for interacting with Meraki's public API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/actionBatchHelpers.ts
+++ b/src/actionBatchHelpers.ts
@@ -86,7 +86,7 @@ const batchedApiRequest = async (
 
       if (apiCheckResp.data?.status?.completed) {
         return apiCheckResp;
-      } else if (apiResp.data?.status?.failed) {
+      } else if (apiCheckResp.data?.status?.failed) {
         return Promise.reject(makeFailResponseObj(apiCheckResp));
       } else {
         await sleep(interval);


### PR DESCRIPTION
I noticed that creating an action batch that returns an error that the library continues to make API requests to the back-end in a loop, with no throttling. This is because the API response that is being checked is the initial POST response, not the current GET status response. If the initial response doesn't return an error, then the error condition never gets tripped.

This commit fixes that bug, and adds a test. I also bumped the version of the package by a patch-level change.