### PR TITLE
fix: return undefined for unparsable API responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-meraki/dashboard-api-tools",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cisco-meraki/dashboard-api-tools",
   "author": "Cisco Meraki",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Typescript library for interacting with Meraki's public API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/apiUtils.ts
+++ b/src/apiUtils.ts
@@ -79,7 +79,7 @@ const successResponse = async <ResponseData>(response: Response): Promise<ApiRes
   try {
     responseData = await response.json();
   } catch {
-    responseData = {};
+    responseData = undefined;
   }
 
   const responseMetadata = extractCustomHeaders(response);

--- a/test/ApiUtils.test.ts
+++ b/test/ApiUtils.test.ts
@@ -95,10 +95,10 @@ describe("ApiUtils", () => {
           ) as jest.Mock;
         });
 
-        it("returns empty object for data", async () => {
+        it("returns undefined for data", async () => {
           const apiResponse = await apiRequest("GET", "www.fakeurl.com");
 
-          expect(apiResponse.data).toEqual({});
+          expect(apiResponse.data).toBeUndefined();
         });
       });
 
@@ -112,10 +112,10 @@ describe("ApiUtils", () => {
           ) as jest.Mock;
         });
 
-        it("returns empty object for data", async () => {
+        it("returns undefined for data", async () => {
           const apiResponse = await apiRequest("GET", "www.fakeurl.com");
 
-          expect(apiResponse.data).toEqual({});
+          expect(apiResponse.data).toBeUndefined();
         });
       });
 


### PR DESCRIPTION
If the API response is successful, but the JSON is unparsable, then we should not return an empty object.

Return undefined instead so callers can correctly treat unparsable or empty responses as missing data.